### PR TITLE
feat: 이메일 중복 확인 요청

### DIFF
--- a/src/components/JoinForm.tsx
+++ b/src/components/JoinForm.tsx
@@ -1,8 +1,11 @@
 import React, {ChangeEvent} from "react";
 import useAuthStore from "../store/authStore";
-import {CheckDuplicateNickname, fileUpload, signUp} from "../lib/api/auth";
+import {CheckDuplicateEmail, CheckDuplicateNickname, fileUpload, signUp} from "../lib/api/auth";
 
 const JoinForm: React.FC = () => {
+    const [checkDuplicateNickname, setCheckDuplicateNickname] = React.useState<boolean>(true);
+    const [checkDuplicateEmail, setCheckDuplicateEmail] = React.useState<boolean>(true);
+
     const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (file) {
@@ -75,11 +78,22 @@ const JoinForm: React.FC = () => {
                             id="email"
                             type="email"
                             value={email}
+                            readOnly={!checkDuplicateEmail}
                             onChange={(e) => setEmail(e.target.value)}
                         />
                         <button
                             className='border-2 border-gray-300 hover:bg-gray-400'
-                            onClick={() => {alert('중복검사 API 호출 예정')}}
+                            onClick={(e) => {
+                                e.preventDefault();
+                                CheckDuplicateEmail({email : email}).then((response) => {
+                                    if(response.data.result) {
+                                        alert("사용 가능한 이메일입니다.");
+                                        setCheckDuplicateEmail(false);
+                                    }
+                                    else alert("이미 사용 중인 이메일입니다.");
+                                })
+                                    .catch(() => alert("중복 검사 실패"));
+                            }}
                         >중복 검사
                         </button>
                     </div>
@@ -92,6 +106,7 @@ const JoinForm: React.FC = () => {
                         id="nickname"
                         type="text"
                         value={nickname}
+                        readOnly={!checkDuplicateNickname}
                         onChange={(e) => setNickname(e.target.value)}
                     />
                     <button
@@ -99,7 +114,10 @@ const JoinForm: React.FC = () => {
                         onClick={(e) => {
                             e.preventDefault();
                             CheckDuplicateNickname({nickname: nickname}).then((response) => {
-                                if(response.data.result) alert("사용 가능한 이름입니다.");
+                                if(response.data.result) {
+                                    alert("사용 가능한 이름입니다.");
+                                    setCheckDuplicateNickname(false);
+                                }
                                 else alert("이미 사용 중인 이름입니다.");
                             })
                                 .catch(() => alert("중복 검사 실패"));
@@ -130,6 +148,7 @@ const JoinForm: React.FC = () => {
                 <button
                     type="submit"
                     className='border-2 border-gray-300 hover:bg-gray-400'
+                    disabled={checkDuplicateNickname && checkDuplicateEmail}
                 >회원가입</button>
             </form>
         </div>

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -16,6 +16,10 @@ interface CheckNicknameParams {
     nickname: string,
 }
 
+interface CheckEmailParams {
+    email: string,
+}
+
 interface FileUploadParams {
     file: File | null;
 }
@@ -27,6 +31,13 @@ export const signUp = (body: SignUpParams) => client.post('/auth/signUp', ({body
 export const CheckDuplicateNickname = ({nickname}: CheckNicknameParams) => (client.get('auth/nicknames', {
         params: {
             nickname,
+        },
+    },
+));
+
+export const CheckDuplicateEmail = ({email}: CheckEmailParams) => (client.get('auth/emails', {
+        params: {
+            email,
         },
     },
 ));


### PR DESCRIPTION
![KakaoTalk_20240614_153059219](https://github.com/wagora-chat/wagora-chat-frontend/assets/100674871/760b7f42-d6c5-4e2b-8810-7259fed8bbb3)
- 이메일 중복 확인 요청 확인(서버 연동 x)
 
![화면 캡처 2024-06-14 153316](https://github.com/wagora-chat/wagora-chat-frontend/assets/100674871/49cd3364-767a-4d77-9f23-ab343da5357c)
- 닉네임 중복 확인 요청 확인(서버 연동 x)

---
- 이메일, 닉네임 중복 확인 여부에 따라 회원 가입 버튼 비활성화 되도록 수정 **=>** _추후 이메일 인증 여부도 추가 예정_
  
- 중복 검사 완료 시 이메일, 닉네임 각 입력 input 비활성화 되도록 수정